### PR TITLE
Make lets_encrypt an async fn.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,10 +60,9 @@ where
             // ACME API provider decides.
             let ord_csr = loop {
                 // are we done?
-                match ord_new.clone().read().unwrap().confirm_validations() {
-                    Some(ord_csr) => break ord_csr,
-                    None => {}
-                };
+                if let Some(ord_csr) = ord_new.clone().read().unwrap().confirm_validations() {
+                    break ord_csr;
+                }
 
                 // Get the possible authorizations (for a single domain
                 // this will only be one element).

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,8 +2,11 @@
 //! website using warp.
 
 use futures::channel::oneshot;
-use futures::executor::block_on;
-use warp::{Filter};
+use futures::try_join;
+use warp::Filter;
+
+static PORT_HTTP: u16 = 80;
+static PORT_HTTPS: u16 = 443;
 
 /// Run forever on the current thread, serving using TLS to serve on the given domain.
 ///
@@ -12,7 +15,7 @@ use warp::{Filter};
 /// to serve port 80 and port 443.  It obtains TLS credentials from
 /// `letsencrypt.org` and then serves up the site on port 443.  It
 /// also serves redirects on port 80.  Errors are reported on stderr.
-pub fn lets_encrypt<F>(service: F, email: &str, domain: &str) -> Result<(), acme_lib::Error>
+pub async fn lets_encrypt<F>(service: F, email: &str, domain: &str) -> Result<(), acme_lib::Error>
 where
     F: warp::Filter<Error = warp::Rejection> + Send + Sync + 'static,
     F::Extract: warp::reply::Reply,
@@ -38,7 +41,8 @@ where
     let acc = dir.account(email)?;
 
     // Order a new TLS certificate for a domain.
-    let mut ord_new = acc.new_order(&domain, &[])?;
+    let ord_new = acc.new_order(&domain, &[])?;
+    let ord_new = std::sync::Arc::new(std::sync::RwLock::new(ord_new));
 
     loop {
         const TMIN: std::time::Duration = std::time::Duration::from_secs(60 * 60 * 24 * 30);
@@ -56,71 +60,76 @@ where
             // ACME API provider decides.
             let ord_csr = loop {
                 // are we done?
-                if let Some(ord_csr) = ord_new.confirm_validations() {
-                    break ord_csr;
-                }
+                match ord_new.clone().read().unwrap().confirm_validations() {
+                    Some(ord_csr) => break ord_csr,
+                    None => {}
+                };
 
                 // Get the possible authorizations (for a single domain
                 // this will only be one element).
-                let auths = ord_new.authorizations()?;
+                let authorizations = {
+                    let ord_new = ord_new.clone();
+                    tokio::task::spawn_blocking(move || ord_new.read().unwrap().authorizations())
+                        .await
+                        .expect("authorizations could not spawned")?
+                };
 
                 // For HTTP, the challenge is a text file that needs to
-                // be placed in your web server's root:
+                // be placed in your web server at:
                 //
-                // /var/www/.well-known/acme-challenge/<token>
+                //   .well-known/acme-challenge/<token>
                 //
                 // The important thing is that it's accessible over the
                 // web for the domain(s) you are trying to get a
                 // certificate for:
                 //
                 // http://mydomain.io/.well-known/acme-challenge/<token>
-                let chall = auths[0].http_challenge();
-
-                // The token is the filename.
-                let token: &'static str = Box::leak(chall.http_token().to_string().into_boxed_str());
-
-                // The proof is the contents of the file
-                let proof = chall.http_proof();
-
-                // Here you must do "something" to place
-                // the file/contents in the correct place.
-                // update_my_web_server(&path, &proof);
-                let domain = domain.to_string();
-                use std::str::FromStr;
-                let token = warp::path!(".well-known" / "acme-challenge")
-                    .and(warp::path(token))
-                    .map(move || proof.clone());
-                let redirect = warp::path::tail().map(move |path: warp::path::Tail| {
-                    println!("redirecting to https://{}/{}", domain, path.as_str());
-                    warp::redirect::redirect(
-                        warp::http::Uri::from_str(&format!(
-                            "https://{}/{}",
-                            &domain,
-                            path.as_str()
-                        ))
-                            .expect("problem with uri?"),
-                    )
-                });
-                let (tx80, rx80) = oneshot::channel();
-                std::thread::spawn(|| {
-                    block_on(warp::serve(token.or(redirect))
-                               .bind_with_graceful_shutdown(([0, 0, 0, 0], 80),  async { rx80.await.ok(); })
-                               .1);
-                });
-
-                // After the file is accessible from the web, the calls
-                // this to tell the ACME API to start checking the
-                // existence of the proof.
                 //
-                // The order at ACME will change status to either
-                // confirm ownership of the domain, or fail due to the
-                // not finding the proof. To see the change, we poll
-                // the API with 5000 milliseconds wait between.
-                chall.validate(5000)?;
-                tx80.send(()).unwrap(); // Now stop the server on port 80
+                for authorization in authorizations {
+                    let challenge = authorization.http_challenge();
+
+                    let token: String = challenge.http_token().into();
+                    let proof: String = challenge.http_proof();
+                    let service = warp::path!(".well-known" / "acme-challenge" / ..)
+                        .and(warp::path(token))
+                        .map(move || proof.clone());
+
+                    // Start up a short-lived server on port 80 to respond to
+                    // the ACME provider's probes.
+                    let (tx80, rx80) = oneshot::channel();
+                    let s_validate = tokio::spawn(async move {
+                        warp::serve(service)
+                            .bind_with_graceful_shutdown(([0, 0, 0, 0], PORT_HTTP), async {
+                                rx80.await.ok();
+                            })
+                            .1
+                            .await
+                    });
+
+                    // After the file is accessible from the web, the calls this
+                    // to tell the ACME API to start checking the existence of
+                    // the proof.
+                    //
+                    // The order at ACME will change status to either confirm
+                    // ownership of the domain, or fail due to the not finding
+                    // the proof. To see the change, we poll the API with 5000
+                    // milliseconds wait between.
+                    tokio::task::spawn_blocking(|| challenge.validate(5000))
+                        .await
+                        .expect("spawning validation failed")?;
+                    tx80.send(()).unwrap(); // Now stop the server on port 80
+                    s_validate
+                        .await
+                        .expect("validation server did not shut down gracefully");
+                }
 
                 // Update the state against the ACME API.
-                ord_new.refresh()?;
+                {
+                    let ord_new = ord_new.clone();
+                    tokio::task::spawn_blocking(move || ord_new.write().unwrap().refresh())
+                        .await
+                        .expect("spawning refresh failed")?;
+                }
             };
 
             // Ownership is proven. Create a private/public key pair for the
@@ -131,8 +140,7 @@ where
             // Submit the CSR. This causes the ACME provider to enter a state
             // of "processing" that must be polled until the certificate is
             // either issued or rejected. Again we poll for the status change.
-            let ord_cert =
-                ord_csr.finalize_pkey(pkey_pri, pkey_pub, 5000)?;
+            let ord_cert = ord_csr.finalize_pkey(pkey_pri, pkey_pub, 5000)?;
 
             // Now download the certificate. Also stores the cert in the
             // persistence.
@@ -143,66 +151,68 @@ where
 
         // Now we have working keys, let us use them!
         let (tx80, rx80) = oneshot::channel();
-        {
+        let s80 = {
             // First start the redirecting from port 80 to port 443.
             let domain = domain.to_string();
             use std::str::FromStr;
             let redirect = warp::path::tail().map(move |path: warp::path::Tail| {
                 println!("redirecting to https://{}/{}", domain, path.as_str());
                 warp::redirect::redirect(
-                    warp::http::Uri::from_str(&format!(
-                        "https://{}/{}",
-                        &domain,
-                        path.as_str()
-                    ))
+                    warp::http::Uri::from_str(&format!("https://{}/{}", &domain, path.as_str()))
                         .expect("problem with uri?"),
                 )
             });
-            std::thread::spawn(|| {
-                block_on(warp::serve(redirect)
-                         .bind_with_graceful_shutdown(([0, 0, 0, 0], 80), async { rx80.await.ok(); })
-                         .1);
-            });
-        }
+            tokio::spawn(async move {
+                warp::serve(redirect)
+                    .bind_with_graceful_shutdown(([0, 0, 0, 0], PORT_HTTP), async {
+                        rx80.await.ok();
+                    })
+                    .1
+                    .await
+            })
+        };
         let (tx, rx) = oneshot::channel();
-        {
+        let s443 = {
             // Now start our actual site.
             let service = service.clone();
             let key_name = key_name.clone();
             let pem_name = pem_name.clone();
-            std::thread::spawn(move || {
-                block_on(warp::serve(service)
-                         .tls()
-                         .cert_path(&pem_name)
-                         .key_path(&key_name)
-                         .bind_with_graceful_shutdown(([0, 0, 0, 0], 443), async { rx.await.ok(); })
-                         .1);
-            });
-        }
+            tokio::spawn(async move {
+                warp::serve(service)
+                    .tls()
+                    .cert_path(&pem_name)
+                    .key_path(&key_name)
+                    .bind_with_graceful_shutdown(([0, 0, 0, 0], PORT_HTTPS), async {
+                        rx.await.ok();
+                    })
+                    .1
+                    .await
+            })
+        };
 
         // Now wait until it is time to grab a new certificate.
         if let Some(time_to_renew) = time_to_expiration(&pem_name).and_then(|x| x.checked_sub(TMIN))
         {
             println!("Sleeping for {:?} before renewing", time_to_renew);
-            std::thread::sleep(time_to_renew);
+            tokio::time::delay_for(time_to_renew).await;
             println!("Now it is time to renew!");
             tx.send(()).unwrap();
             tx80.send(()).unwrap();
-            std::thread::sleep(std::time::Duration::from_secs(1)); // FIXME very hokey!
+            try_join!(s80, s443).expect("server did not shutdown gracefully");
         } else if let Some(time_to_renew) = time_to_expiration(&pem_name) {
             // Presumably we already failed to renew, so let's
             // just keep using our current certificate as long
             // as we can!
             println!("Sleeping for {:?} before renewing", time_to_renew);
-            std::thread::sleep(time_to_renew);
+            tokio::time::delay_for(time_to_renew).await;
             println!("Now it is time to renew!");
             tx.send(()).unwrap();
             tx80.send(()).unwrap();
-            std::thread::sleep(std::time::Duration::from_secs(1)); // FIXME very hokey!
+            try_join!(s80, s443).expect("server did not shutdown gracefully");
         } else {
             println!("Uh oh... looks like we already are at our limit?");
             println!("Waiting an hour before trying again...");
-            std::thread::sleep(std::time::Duration::from_secs(60 * 60));
+            tokio::time::delay_for(std::time::Duration::from_secs(60 * 60)).await;
         }
     }
 }


### PR DESCRIPTION
Hi David,

The `lets_encrypt` function wasn't working for me so I changed it to run async. I also made it more general, in that it will process every authorisation. That doesn't buy anything yet, because this only ever requests a single authorisation, but it's something I'd like to work on.

This is a first time with async in Rust so it might be bad style or wrong, but I have experience of async programming in general. The one thing I can say is that this works for me.

I hope you find this interesting.
